### PR TITLE
Added UI to select an existing VNET gateway

### DIFF
--- a/AVS-Landing-Zone/GreenField/PortalUI/ARM/ESLZdeploy.PortalUI.json
+++ b/AVS-Landing-Zone/GreenField/PortalUI/ARM/ESLZdeploy.PortalUI.json
@@ -384,13 +384,22 @@
                             }
                         },
                         {
-                            "name": "gatewaySelectorId",
-                            "type": "Microsoft.Solutions.ResourceSelector",
-                            "visible": "[equals(steps('azureNetwork').GatewayExists, true)]",
+                            "name": "virtualNetworkGatewaysApi",
+                            "type": "Microsoft.Solutions.ArmApiControl",
+                            "request": {
+                                "method": "GET",
+                                "path": "[concat(steps('basics').resourceScope.subscription.id, '/providers/Microsoft.Network/virtualNetworkGateways?api-version=2022-11-01')]"
+                            }
+                        },
+                        {
+                            "name": "virtualNetworkGateway",
+                            "type": "Microsoft.Common.DropDown",
+                            "visible": "[equals(steps('aib').virtualNetwork, true)]",
                             "label": "Select Existing ExpressRoute Gateway",
-                            "resourceType": "Microsoft.Network/virtualNetworkGateways",
+                            "defaultValue": "",
+                            "toolTip": "",
                             "constraints": {
-                                "required": true
+                                "allowedValues": "[map(filter(steps('azureNetwork').virtualNetworkGatewaysApi.value, (item) => contains(first(item.properties.ipConfigurations).properties.subnet.id, steps('azureNetwork').VnetSelectorId.name)), (item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.name, '\"}')))]"
                             }
                         },
                         {
@@ -988,7 +997,7 @@
                 "DeployNetworking": "[steps('azureNetwork').DeployNetworking]",
                 "ExistingVnetName": "[steps('azureNetwork').VnetSelectorId.name]",
                 "GatewayExists": "[steps('azureNetwork').GatewayExists]",
-                "ExistingGatewayName": "[steps('azureNetwork').gatewaySelectorId.name]",
+                "ExistingGatewayName": "[steps('azureNetwork').virtualNetworkGateway]",
                 "GatewaySubnetExists": "[if(equals(steps('azureNetwork').GatewayExists, true), true, steps('azureNetwork').GatewaySubnetExists)]",
                 "ExistingGatewaySubnetId": "[steps('azureNetwork').gatewaySubnetSubnetSelectorName]",
                 "NewVNetAddressSpace": "[if(equals(steps('azureNetwork').VNetExists, false), steps('azureNetwork').vNetAddressSpace, 'none')]",

--- a/AVS-Landing-Zone/GreenField/PortalUI/ARM/ESLZdeploy.PortalUI.json
+++ b/AVS-Landing-Zone/GreenField/PortalUI/ARM/ESLZdeploy.PortalUI.json
@@ -388,7 +388,7 @@
                             "type": "Microsoft.Solutions.ArmApiControl",
                             "request": {
                                 "method": "GET",
-                                "path": "[concat(steps('basics').resourceScope.subscription.id, '/providers/Microsoft.Network/virtualNetworkGateways?api-version=2022-11-01')]"
+                                "path": "[concat(steps('basics').avsDeploymentScope.subscription.id, '/providers/Microsoft.Network/virtualNetworkGateways?api-version=2022-11-01')]"
                             }
                         },
                         {

--- a/AVS-Landing-Zone/GreenField/PortalUI/ARM/ESLZdeploy.PortalUI.json
+++ b/AVS-Landing-Zone/GreenField/PortalUI/ARM/ESLZdeploy.PortalUI.json
@@ -394,7 +394,7 @@
                         {
                             "name": "virtualNetworkGateway",
                             "type": "Microsoft.Common.DropDown",
-                            "visible": "[equals(steps('aib').virtualNetwork, true)]",
+                            "visible": "[equals(steps('azureNetwork').GatewayExists, true)]",
                             "label": "Select Existing ExpressRoute Gateway",
                             "defaultValue": "",
                             "toolTip": "",


### PR DESCRIPTION
# Overview/Summary

Add the UI elements to select an existing VNET gateway that's associated with the existing, selected VNET.

## This PR fixes/adds/changes/removes

1. Adds two UI elements

### Breaking Changes

1. None

## Testing Evidence

![image](https://github.com/shaunjacob/Enterprise-Scale-for-AVS-Fork/assets/61800683/38870100-3339-4f32-ad7e-c4445e90b3f8)


## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale-for-AVS/pulls)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale-for-AVS/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.
